### PR TITLE
Use  /dev/serial/by-id to pick up HiKey serial port

### DIFF
--- a/hisi-idt.py
+++ b/hisi-idt.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+#-*- coding: utf-8 -*-
 
 import os
 import os.path
@@ -224,7 +225,7 @@ def main(argv):
     '''
     img1 = 'fastboot1.img'
     img2 = ''
-    dev  = '/dev/ttyUSB0'
+    dev  = '/dev/serial/by-id/usb-䕇䕎䥎_㄰㌲㔴㜶㤸-if00-port0'
     try:
         opts, args = getopt.getopt(argv,"hd:",["img1=","img2="])
     except getopt.GetoptError:


### PR DESCRIPTION
The /dev/serial/by-id has existed since 2008, and the bootrom(?) always
outputs same ID when in recovery. This should be a safer default than
looking at dmesg.

Signed-off-by: Riku Voipio riku.voipio@linaro.org
