### PR TITLE
Update default device path for Ubuntu 15.10

### DIFF
--- a/hisi-idt.py
+++ b/hisi-idt.py
@@ -225,7 +225,9 @@ def main(argv):
     '''
     img1 = 'fastboot1.img'
     img2 = ''
-    dev  = '/dev/serial/by-id/usb-䕇䕎䥎_㄰㌲㔴㜶㤸-if00-port0'
+    dev  = '';
+    dev1 = '/dev/serial/by-id/usb-䕇䕎䥎_㄰㌲㔴㜶㤸-if00-port0'
+    dev2 = '/dev/serial/by-id/pci-䕇䕎䥎_㄰㌲㔴㜶㤸-if00-port0'
     try:
         opts, args = getopt.getopt(argv,"hd:",["img1=","img2="])
     except getopt.GetoptError:
@@ -241,6 +243,14 @@ def main(argv):
             img1 = arg
         elif opt in ("--img2"):
             img2 = arg
+    if dev == '':
+        if os.path.exists(dev1):
+            dev = dev1
+        elif os.path.exists(dev2):
+            dev = dev2
+        else:
+            print 'Device not detected under /dev/serial/by-id/. Please use -d.'
+            sys.exit(3)
     print '+----------------------+'
     print ' Serial: ', dev
     print ' Image1: ', img1


### PR DESCRIPTION
With Ubuntu 15.10, the HiKey board in recovery mode is accessible as
/dev/serial/by-id/pci-<xyz> instead of /dev/serial/by-id/usb-<xyz>
previously (15.04). With this commit, the script will try both paths
in case no device is specified on the command line.

Signed-off-by: Jerome Forissier jerome.forissier@linaro.org
